### PR TITLE
Url arg

### DIFF
--- a/iiifcollectionbrowse/blueprint/__init__.py
+++ b/iiifcollectionbrowse/blueprint/__init__.py
@@ -143,8 +143,12 @@ def collection():
                 )
             )
 
+    # Be sure the interface can render this record,
+    # as some valid records may be unrenderable due
+    # to technical constraints.
     if not record_compatible(rj):
         raise IncompatibleRecordError()
+
     # Parse the record
     members = []
     collections = []

--- a/iiifcollectionbrowse/blueprint/exceptions.py
+++ b/iiifcollectionbrowse/blueprint/exceptions.py
@@ -26,3 +26,11 @@ class NoCollectionFoundError(Error):
 class InvalidCollectionRecordError(Error):
     err_name = "InvalidCollectionRecordError"
     status_code = 500
+
+class NoCollectionParameterError(Error):
+    err_name = "NoCollectionParameterError"
+    status_code = 500
+    message = "You don't appear to have included " + \
+    "a collection record query parameter (and no " + \
+    "default is set)."
+

--- a/iiifcollectionbrowse/blueprint/exceptions.py
+++ b/iiifcollectionbrowse/blueprint/exceptions.py
@@ -27,10 +27,17 @@ class InvalidCollectionRecordError(Error):
     err_name = "InvalidCollectionRecordError"
     status_code = 500
 
+
 class NoCollectionParameterError(Error):
     err_name = "NoCollectionParameterError"
     status_code = 500
     message = "You don't appear to have included " + \
-    "a collection record query parameter (and no " + \
-    "default is set)."
+        "a collection record query parameter (and no " + \
+        "default is set)."
 
+
+class IncompatibleRecordError(Error):
+    err_name = "IncompatibleRecordError"
+    status_code = 500
+    message = "That record appears to be incompatible " + \
+        "with this interface, sorry!"

--- a/iiifcollectionbrowse/blueprint/exceptions.py
+++ b/iiifcollectionbrowse/blueprint/exceptions.py
@@ -17,3 +17,12 @@ class Error(Exception):
 # the included app errorhandler is used, or if whatever
 # application mounts the blueprint implements a similar
 # error handler.
+
+class NoCollectionFoundError(Error):
+    err_name = "NoCollectionFoundError"
+    status_code = 404
+
+
+class InvalidCollectionRecordError(Error):
+    err_name = "InvalidCollectionRecordError"
+    status_code = 500


### PR DESCRIPTION
Changes the handling of the collection record to be part of the URL query string, rather than a portion of the path itself.

Adds an option to set a default collection record to render, via inserting something like

```
from os import environ
environ['IIIFCOLLBROWSE_DEFAULT_COLL'] ="https://your-collection-server.com/top.json"
```
to the **top** of the .wsgi file, so it is run before the application is imported. 

Abstracts out building the template URLs into a separate function.

Lots of docstrings

more verbose exceptions